### PR TITLE
Add support for getting display type

### DIFF
--- a/components/t547/t547.h
+++ b/components/t547/t547.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/version.h"
 #include "esphome/components/display/display_buffer.h"
 
 #include "epd_driver.h"
@@ -30,10 +31,12 @@ class T547 : public PollingComponent, public display::DisplayBuffer {
 
   uint8_t get_panel_state() { return this->panel_on_; }
   bool get_greyscale() { return this->greyscale_; }
- 
+
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2022,6,0) 
   display::DisplayType get_display_type() override {
     return get_greyscale() ? display::DisplayType::DISPLAY_TYPE_GRAYSCALE : display::DisplayType::DISPLAY_TYPE_BINARY;
   }
+#endif
 
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;

--- a/components/t547/t547.h
+++ b/components/t547/t547.h
@@ -30,6 +30,10 @@ class T547 : public PollingComponent, public display::DisplayBuffer {
 
   uint8_t get_panel_state() { return this->panel_on_; }
   bool get_greyscale() { return this->greyscale_; }
+ 
+  display::DisplayType get_display_type() override {
+    return get_greyscale() ? display::DisplayType::DISPLAY_TYPE_GRAYSCALE : display::DisplayType::DISPLAY_TYPE_BINARY;
+  }
 
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;


### PR DESCRIPTION
A breaking change PR (https://github.com/esphome/esphome/pull/3430) was merged into esphome that will prevent your code from compiling.
Adding this change will allow it to build again on ESPHome >= 2022.6
