### PR TITLE
Add support for color inversion

### DIFF
--- a/components/t547/display.py
+++ b/components/t547/display.py
@@ -4,6 +4,7 @@ from esphome import pins
 from esphome.components import display
 from esphome.const import (
     CONF_ID,
+    CONF_INVERT,
     CONF_LAMBDA,
     CONF_PAGES,
 )
@@ -11,7 +12,6 @@ from esphome.const import (
 DEPENDENCIES = ["esp32"]
 
 CONF_GREYSCALE = "greyscale"
-
 
 t547_ns = cg.esphome_ns.namespace("t547")
 T547 = t547_ns.class_(
@@ -23,6 +23,7 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(T547),
             cv.Optional(CONF_GREYSCALE, default=False): cv.boolean,
+            cv.Optional(CONF_INVERT, default=True): cv.boolean,
         }
     )
     .extend(cv.polling_component_schema("5s")),
@@ -44,5 +45,6 @@ async def to_code(config):
         cg.add(var.set_writer(lambda_))
 
     cg.add(var.set_greyscale(config[CONF_GREYSCALE]))
+    cg.add(var.set_invert(config[CONF_INVERT]))
 
     cg.add_build_flag("-DBOARD_HAS_PSRAM")

--- a/components/t547/t547.cpp
+++ b/components/t547/t547.cpp
@@ -20,7 +20,7 @@ void T547::setup() {
 }
 
 void T547::initialize_() {
-  ESP_LOGV(TAG, "Initialize called");  
+  ESP_LOGV(TAG, "Initialize called");
   uint32_t buffer_size = this->get_buffer_length_();
 
   if (this->buffer_ != nullptr) {
@@ -36,9 +36,9 @@ void T547::initialize_() {
     this->mark_failed();
     return;
   }
-
-  memset(this->buffer_, 255, buffer_size);
-  ESP_LOGV(TAG, "Initialize complete");  
+  uint8_t background = invert_ ? 255 : 0;
+  memset(this->buffer_, background, buffer_size);
+  ESP_LOGV(TAG, "Initialize complete");
 }
 
 float T547::get_setup_priority() const { return setup_priority::PROCESSOR; }
@@ -54,7 +54,10 @@ void T547::update() {
 void HOT T547::draw_absolute_pixel_internal(int x, int y, Color color) {
   if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
     return;
-  uint8_t gs = 255 - ((color.red * 2126 / 10000) + (color.green * 7152 / 10000) + (color.blue * 722 / 10000));
+  uint8_t gs = ((color.red * 2126 / 10000) + (color.green * 7152 / 10000) + (color.blue * 722 / 10000));
+  if (invert_) {
+    gs = 255 - gs;
+  }
   epd_draw_pixel(x, y, gs, this->buffer_);
 }
 
@@ -75,7 +78,7 @@ void T547::eink_on_() {
   ESP_LOGV(TAG, "Eink on called");
   if (panel_on_ == 1)
     return;
-  epd_poweron();    
+  epd_poweron();
   panel_on_ = 1;
 }
 

--- a/components/t547/t547.h
+++ b/components/t547/t547.h
@@ -18,6 +18,7 @@ class T547 : public PollingComponent, public display::DisplayBuffer {
     this->greyscale_ = greyscale;
     this->initialize_();
   }
+  void set_invert(bool invert) { this->invert_ = invert; }
 
   float get_setup_priority() const override;
 
@@ -32,7 +33,7 @@ class T547 : public PollingComponent, public display::DisplayBuffer {
   uint8_t get_panel_state() { return this->panel_on_; }
   bool get_greyscale() { return this->greyscale_; }
 
-#if ESPHOME_VERSION_CODE >= VERSION_CODE(2022,6,0) 
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2022,6,0)
   display::DisplayType get_display_type() override {
     return get_greyscale() ? display::DisplayType::DISPLAY_TYPE_GRAYSCALE : display::DisplayType::DISPLAY_TYPE_BINARY;
   }
@@ -52,12 +53,11 @@ class T547 : public PollingComponent, public display::DisplayBuffer {
 
   size_t get_buffer_length_();
 
-
   uint8_t panel_on_ = 0;
   uint8_t temperature_;
 
   bool greyscale_;
-
+  bool invert_;
 };
 
 }  // namespace T547


### PR DESCRIPTION
Currently, when drawing to the screen, using "Color::WHITE" paints a black pixel and "Color::BLACK" paints a white one. Also when using grayscale images, the image appears inverted (i.e. negative) by default.

With this commit, a new option "white_is_on" is added, to invert the colors and let "white" show as white and black as black