### PR TITLE
Fix register component for upcoming ESPHome 2023.12.0

### DIFF
--- a/components/t547/display.py
+++ b/components/t547/display.py
@@ -36,7 +36,9 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 
-    await cg.register_component(var, config)
+    if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.12.0"):
+        await cg.register_component(var, config)
+
     await display.register_display(var, config)
 
     if CONF_LAMBDA in config:

--- a/components/t547/display.py
+++ b/components/t547/display.py
@@ -8,6 +8,7 @@ from esphome.const import (
     CONF_LAMBDA,
     CONF_PAGES,
 )
+from esphome.const import __version__ as ESPHOME_VERSION
 
 DEPENDENCIES = ["esp32"]
 
@@ -39,8 +40,12 @@ async def to_code(config):
     await display.register_display(var, config)
 
     if CONF_LAMBDA in config:
+        if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.7.0"):
+            displayRef = display.DisplayBufferRef
+        else:
+            displayRef = display.DisplayRef
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(displayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))
 

--- a/components/t547/t547.h
+++ b/components/t547/t547.h
@@ -12,7 +12,11 @@
 namespace esphome {
 namespace t547 {
 
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2023,12,0)
+class T547 : public display::DisplayBuffer {
+#else
 class T547 : public PollingComponent, public display::DisplayBuffer {
+#endif // VERSION_CODE(2023,12,0)
  public:
   void set_greyscale(bool greyscale) {
     this->greyscale_ = greyscale;


### PR DESCRIPTION
On the (upcoming) ESPHome version 2023.12.0,  there was a change in the basic display component, which slightly simplifies the way displays are registered.
That change requires removing the component registration code from the display implementations.

This PR is based on top of #9, which fixes another refactoring that happened on the 2023.7.0

